### PR TITLE
Hotfix 3.3.8 (#2888)

### DIFF
--- a/classes/GeographicThesaurus.php
+++ b/classes/GeographicThesaurus.php
@@ -1,8 +1,19 @@
 <?php
 include_once($SERVER_ROOT . '/classes/Manager.php');
 include_once($SERVER_ROOT . '/classes/utilities/QueryUtil.php');
+include_once($SERVER_ROOT . '/classes/Database.php');
 
 class GeographicThesaurus extends Manager {
+	const US_STATE_LIST = array('AK' => 'Alaska', 'AL' => 'Alabama', 'AZ' => 'Arizona', 'AR' => 'Arkansas', 'CA' => 'California',
+		'CO' => 'Colorado', 'CT' => 'Connecticut', 'DE' => 'Delaware', 'DC' => 'District of Columbia', 'FL' => 'Florida',
+		'GA' => 'Georgia', 'GU' => 'Guam', 'HI' => 'Hawaii', 'ID' => 'Idaho', 'IL' => 'Illinois', 'IN' => 'Indiana', 'IA' =>
+		'Iowa', 'KS' => 'Kansas', 'KY' => 'Kentucky', 'LA' => 'Louisiana', 'ME' => 'Maine', 'MH' => 'Marshall Islands', 'MD' =>
+		'Maryland', 'MA' => 'Massachusetts', 'MI' => 'Michigan', 'MN' => 'Minnesota', 'MS' => 'Mississippi', 'MO' => 'Missouri',
+		'MT' => 'Montana', 'NE' => 'Nebraska', 'NV' => 'Nevada', 'NH' => 'New Hampshire', 'NJ' => 'New Jersey', 'NM' => 'New Mexico',
+		'NY' => 'New York', 'NC' => 'North Carolina', 'ND' => 'North Dakota', 'MP' => 'Northern Mariana Islands', 'OH' => 'Ohio',
+		'OK' => 'Oklahoma', 'OR' => 'Oregon', 'PW' => 'Palau', 'PA' => 'Pennsylvania', 'PR' => 'Puerto Rico', 'RI' => 'Rhode Island',
+		'SC' => 'South Carolina', 'SD' => 'South Dakota', 'TN' => 'Tennessee', 'TX' => 'Texas', 'UT' => 'Utah', 'VT' => 'Vermont',
+		'VI' => 'Virgin Islands', 'VA' => 'Virginia', 'WA' => 'Washington', 'WV' => 'West Virginia', 'WI' => 'Wisconsin', 'WY' =>  'Wyoming');
 
 	function __construct() {
 		parent::__construct(null, 'write');
@@ -41,6 +52,38 @@ class GeographicThesaurus extends Manager {
 			}
 		}
 		return $retArr;
+	}
+
+	public static function getCountryByState($state, $conn = null) {
+		if(!$state) { 
+			return '';
+		}
+
+		if(in_array(ucwords($state),self::US_STATE_LIST)) {
+			return 'United States';
+		}
+
+		if(!$conn) {
+			$conn = Database::connect('readonly');
+		}
+
+		$countryStr = '';
+		$rs = QueryUtil::executeQuery($conn, 'SELECT c.geoTerm AS countryName FROM geographicthesaurus s INNER JOIN geographicthesaurus c ON s.parentID = c.geoThesID WHERE s.geoTerm = ?', [ $state ]);
+
+		if($r = $rs->fetch_object()) {
+			$countryStr = $r->countryName;
+		}
+		$rs->free();
+
+		return $countryStr;
+	}
+
+	public static function getStateByAbbreviationUs($abbr){
+		$stateStr = '';
+		if(array_key_exists($abbr,self::US_STATE_LIST)){
+			$stateStr = self::US_STATE_LIST[$abbr];
+		}
+		return $stateStr;
 	}
 
 	public function getGeograpicUnit($geoThesID) {

--- a/classes/OccurrenceEditorManager.php
+++ b/classes/OccurrenceEditorManager.php
@@ -1284,6 +1284,7 @@ class OccurrenceEditorManager {
 	public function addOccurrence($postArr) {
 		global $LANG;
 		$status = $LANG['SUCCESS_NEW_OCC_SUBMITTED'];
+
 		if ($postArr) {
 			$postArr = array_merge($postArr, $this->getDatefields($postArr));
 			$guid = UuidFactory::getUuidV4();

--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -664,11 +664,6 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 			if($v) $retStr .= '&'. $this->cleanOutStr($k) . '=' . $this->cleanOutStr($v);
 		}
 		if(isset($this->taxaArr['search'])){
-			if (
-				isset($this->taxaArr['taxontype']) && $this->taxaArr['taxontype'] == 1 &&
-				preg_match('/^[^:]+:\s*(.+)$/', $this->taxaArr['search'], $matches)
-			)
-				$this->taxaArr['search'] = $matches[1];
 			$patternTaxonChars = '/^[a-zA-Z0-9\s\-\,\.×†]*$/';
 			if (preg_match($patternTaxonChars, $this->getTaxaSearchTerm())==1) {
 				$retStr .= '&taxa=' . $this->getTaxaSearchTerm();

--- a/classes/OccurrenceTaxaManager.php
+++ b/classes/OccurrenceTaxaManager.php
@@ -259,6 +259,7 @@ class OccurrenceTaxaManager {
 		else{
 			$taxaStr = str_replace(';',',',$this->cleanInputStr($_REQUEST['taxa']));
 		}
+		$taxaStr = str_replace('_', ' ',$taxaStr);
 		if($taxaStr){
 			$this->taxaArr['search'] = $taxaStr;
 			//Set usage of taxonomic thesaurus
@@ -634,7 +635,6 @@ class OccurrenceTaxaManager {
 	protected function cleanInputStr($str){
 		if(!is_string($str) && !is_numeric($str) && !is_bool($str)) return '';
 		if(preg_match('/^\d+\'+$/', $str)) return 0;	//SQL Injection attempt, thus set to return nothing rather than a query that puts a load on the db server
-		$str = str_replace('_', ' ',$str);
 		$str = preg_replace('/%%+/', '%',$str);
 		$str = preg_replace('/^[\s%]+/', '',$str);
 		$str = trim($str,' ,;');

--- a/classes/OmMaterialSample.php
+++ b/classes/OmMaterialSample.php
@@ -60,7 +60,7 @@ class OmMaterialSample{
 				$stmt->bind_param($this->typeStr, ...$paramArr);
 				if($stmt->execute()){
 					if($stmt->affected_rows || !$stmt->error){
-						$this->assocID = $stmt->insert_id;
+						$this->matSampleID = $stmt->insert_id;
 						$status = true;
 					}
 					else $this->errorMessage = 'ERROR inserting material sample record (2): '.$stmt->error;
@@ -83,7 +83,7 @@ class OmMaterialSample{
 				$sqlFrag .= $fieldName . ' = ?, ';
 				$paramArr[] = $value;
 			}
-			$paramArr[] = $this->assocID;
+			$paramArr[] = $this->matSampleID;
 			$this->typeStr .= 'i';
 			$sql = 'UPDATE ommaterialsample SET '.trim($sqlFrag, ', ').' WHERE (matSampleID = ?)';
 			if($stmt = $this->conn->prepare($sql)) {

--- a/classes/OpenIdProfileManager.php
+++ b/classes/OpenIdProfileManager.php
@@ -63,6 +63,7 @@ class OpenIdProfileManager extends ProfileManager
 
 	public function linkThirdPartySid($thirdparty_sid, $local_sid, $ip)
 	{
+		if (empty($thirdparty_sid)) return;
 		$sql = 'INSERT INTO usersthirdpartysessions(thirdparty_id, localsession_id, ipaddr) VALUES (?, ?, ?)';
 		if ($stmt = $this->conn->prepare($sql)) {
 			if ($stmt->bind_param('sss', $thirdparty_sid, $local_sid, $ip)) {

--- a/classes/TaxonSearchSupport.php
+++ b/classes/TaxonSearchSupport.php
@@ -31,25 +31,25 @@ class TaxonSearchSupport{
 			if($this->taxonType == TaxaSearchType::ANY_NAME){
 			    global $LANG;
 			    $sql =
-			    "SELECT DISTINCT tid, CONCAT('".$LANG['SELECT_1-5'].": ',v.vernacularname) AS sciname ".
+			    "SELECT DISTINCT tid, CONCAT('".$LANG['SELECT_1-5'].": ',v.vernacularname) AS label, v.vernacularname AS sciname ".
 			    "FROM taxavernaculars v ".
 			    "WHERE v.vernacularname LIKE '%".$this->queryString."%' ".
 
 			    "UNION ".
 
-			    "SELECT DISTINCT tid, CONCAT('".$LANG['SELECT_1-2'].": ', sciname) AS sciname ".
+			    "SELECT DISTINCT tid, CONCAT('".$LANG['SELECT_1-2'].": ', sciname) AS label,  sciname AS value ".
 			    "FROM taxa ".
 			    "WHERE sciname LIKE '%".$this->queryString."%' AND rankid > 179 ".
 
 			    "UNION ".
 
-			    "SELECT DISTINCT tid, CONCAT('".$LANG['SELECT_1-3'].": ', sciname) AS sciname ".
+			    "SELECT DISTINCT tid, CONCAT('".$LANG['SELECT_1-3'].": ', sciname) AS label, sciname AS value ".
 			    "FROM taxa ".
 			    "WHERE sciname LIKE '".$this->queryString."%' AND rankid = 140 ".
 
 			    "UNION ".
 
-			    "SELECT tid, CONCAT('".$LANG['SELECT_1-4'].": ',sciname) AS sciname ".
+			    "SELECT tid, CONCAT('".$LANG['SELECT_1-4'].": ',sciname) AS label, sciname AS value ".
 			    "FROM taxa ".
 			    "WHERE sciname LIKE '".$this->queryString."%' AND rankid > 20 AND rankid < 180 AND rankid != 140 ";
 
@@ -74,7 +74,10 @@ class TaxonSearchSupport{
 			}
 			$rs = $this->conn->query($sql);
 			while ($r = $rs->fetch_object()) {
-				$retArr[] = array('id' => $r->tid, 'value' => $r->sciname);
+				$keys = ['id' => $r->tid, 'value' => $r->sciname];
+				if (!empty($r->label))
+					$keys['label'] = $r->label;
+				$retArr[] = $keys;
 			}
 			$rs->free();
 		}

--- a/collections/editor/rpc/occurAddData.php
+++ b/collections/editor/rpc/occurAddData.php
@@ -2,7 +2,8 @@
 include_once(__DIR__ . '/../../../config/symbini.php');
 global $SERVER_ROOT, $IS_ADMIN, $USER_RIGHTS;
 
-include_once($SERVER_ROOT.'/classes/OccurrenceEditorManager.php');
+include_once($SERVER_ROOT . '/classes/OccurrenceEditorManager.php');
+include_once($SERVER_ROOT . '/classes/GeographicThesaurus.php');
 
 $collid = array_key_exists('collid',$_REQUEST);
 $responseArr = array();
@@ -20,6 +21,10 @@ if($collid){
 	if($isEditor){
 		$occurrenceEditor = new OccurrenceEditorManager();
 		$occurrenceEditor->setCollId($_REQUEST['collid']);
+
+		if((!isset($_REQUEST['country']) || !$_REQUEST['country']) && isset($_REQUEST['stateprovince']) && $_REQUEST['stateprovince']){
+			$_REQUEST['country'] = GeographicThesaurus::getCountryByState($_REQUEST['stateprovince']);
+		}
 
 		if(array_key_exists('catalognumber',$_REQUEST) && $occurrenceEditor->catalogNumberExists($_REQUEST['catalognumber'])){
 			$responseArr['occid'] = $occurrenceEditor->getOccId();

--- a/config/symbbase.php
+++ b/config/symbbase.php
@@ -5,7 +5,7 @@ if($GLOBALS['HTTPS_ONLY'] ?? true) {
 	header('strict-transport-security: max-age=600');
 }
 date_default_timezone_set('America/Phoenix');
-$CODE_VERSION = '3.3.7';
+$CODE_VERSION = '3.3.8';
 
 set_include_path(get_include_path() . PATH_SEPARATOR . $SERVER_ROOT . PATH_SEPARATOR . $SERVER_ROOT.'/config/' . PATH_SEPARATOR . $SERVER_ROOT.'/classes/');
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -238,7 +238,9 @@ Symbiota
 NOTE: Do not modify any other css files as these files may be overwritten in future updates
 
 #### Customize language tags
+
 Override existing language tags or create new tags by modifying the override files in content/lang/templates/
+
 Example: modify content/lang/templates/header.es.override.php to replace the default values used when browsing the portal in Spanish.
 
 #### Misc configurations and recommendations

--- a/profile/authCallback.php
+++ b/profile/authCallback.php
@@ -27,7 +27,7 @@ if (array_key_exists('code', $_REQUEST) && $_REQUEST['code']) {
   try{
     $status = $oidc->authenticate();
     $claims = $oidc->getVerifiedClaims();
-    $sid = $claims->sid;
+    $sid = isset($claims->sid) ? $claims->sid : false;
   }
   catch (Exception $ex){
     $_SESSION['last_message'] = $LANG['CAUGHT_EXCEPTION'] . ' ' . $ex->getMessage() . ' <ERR/>';

--- a/profile/openIdAuth.php
+++ b/profile/openIdAuth.php
@@ -15,6 +15,10 @@ $oidc = new OpenIDConnectClient(
   $CLIENT_SECRETS[$AUTH_PROVIDER]
 );
 
+$oidc->addAuthParam(array(
+    'prompt' => 'login'
+));
+
 $oidc->addScope(array('openid'));
 $oidc->addScope(array('email'));
 $oidc->setResponseTypes(array('code'));

--- a/profile/personalspecbackup.php
+++ b/profile/personalspecbackup.php
@@ -12,9 +12,16 @@ $characterSet = array_key_exists('cset',$_REQUEST) ? $_REQUEST['cset'] : 'UTF-8'
 $action = array_key_exists('formsubmit', $_REQUEST) ? $_REQUEST['formsubmit'] : '';
 
 $editable = 0;
-if($IS_ADMIN || !empty($USER_RIGHTS['CollAdmin'][$collid]) || !empty($USER_RIGHTS['CollEditor'][$collid])){
+if($IS_ADMIN){
 	$editable = 1;
 }
+elseif(!empty($USER_RIGHTS['CollAdmin']) && in_array($collid, $USER_RIGHTS['CollAdmin'])){
+	$editable = 1;
+}
+elseif(!empty($USER_RIGHTS['CollEditor']) && in_array($collid, $USER_RIGHTS['CollEditor'])){
+	$editable = 1;
+}
+
 $statusStr = '';
 if($action == 'Perform Backup'){
 	if ($collid) {


### PR DESCRIPTION
* add labels handle for taxa autosuggest (#2856)

* hotfix taxon search with underscore

- Isolate cleaning underscores from search terms to scientific names only

* Bug blocking material sample updates

* Personal specimen download bugfix

- Fixes issue blocking non-superAdmin from downloading backups of personal specimen management Addresses issue #2866

* Add autofill to Add Occurrence Function

# Issue #2874

# Summary
Moves getCountry function to geographic thesaurus from OccurrenceSkeletal and add it to OccurrenceEditorManager's addOccurrence function to keep behavior the same.

* Update symbbase.php

Increment version

* Openid no sid gracefull fail (#2879)

* skip linking sid if none provided.



* Isolate behavior to old skeletal submit

